### PR TITLE
Added error handling for upgradeSoftwareVersion

### DIFF
--- a/server/service/IndividualServicesService.js
+++ b/server/service/IndividualServicesService.js
@@ -100,7 +100,8 @@ exports.bequeathYourDataAndDie = function (body, user, originator, xCorrelator, 
           );
         }
       }
-      softwareUpgrade.upgradeSoftwareVersion(isdataTransferRequired, user, xCorrelator, traceIndicator, customerJourney);
+      softwareUpgrade.upgradeSoftwareVersion(isdataTransferRequired, user, xCorrelator, traceIndicator, customerJourney)
+        .catch(err => console.log(`upgradeSoftwareVersion failed with error: ${err}`));
       resolve();
     } catch (error) {
       reject(error);

--- a/server/service/individualServices/SoftwareUpgrade.js
+++ b/server/service/individualServices/SoftwareUpgrade.js
@@ -25,7 +25,7 @@ const OperationServerInterface = require('onf-core-model-ap/applicationPattern/o
  * @param {String} xCorrelator String UUID for the service execution flow that allows to correlate requests and responses
  * @param {String} traceIndicator String Sequence of request numbers along the flow
  * @param {String} customerJourney String Holds information supporting customer’s journey to which the execution applies
- * @returns {boolean} return true if the operation is success or else return false<br>
+ * @returns {Promise} Promise is resolved if the operation succeeded else the Promise is rejected<br>
  * The following are the list of forwarding-construct that will be automated to transfer the data from this current release to next release
  * 1. PromptForBequeathingDataCausesNewApplicationBeingRequestedToInquireForApplicationTypeApprovals
  * 2. PromptForBequeathingDataCausesTransferOfListOfAlreadyRegisteredApplications


### PR DESCRIPTION
upgradeSoftwareVersion returns Promise which is rejected in case
of any step fails. Rejected Promise was not handled.
This commit adds catching of such case.

Fixes #96 

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>