### PR TITLE
Fixed /deregister-application to call ALT/v1/delete-ltp-and-dependents

### DIFF
--- a/server/service/individualServices/PrepareForwardingAutomation.js
+++ b/server/service/individualServices/PrepareForwardingAutomation.js
@@ -80,7 +80,7 @@ exports.deregisterApplication = function (logicalTerminationPointconfigurationSt
             /***********************************************************************************
              * forwardings for application layer topology
              ************************************************************************************/
-            let applicationLayerTopologyForwardingInputList = await prepareALTForwardingAutomation.getALTForwardingAutomationInputAsync(
+            let applicationLayerTopologyForwardingInputList = await prepareALTForwardingAutomation.getALTUnConfigureForwardingAutomationInputAsync(
                 logicalTerminationPointconfigurationStatus,
                 forwardingConstructConfigurationStatus
             );


### PR DESCRIPTION
it was preparing forwarding with /v1/update-ltp instead of /v1/delete-ltp-and-dependents

Depends on https://github.com/openBackhaul/ApplicationPattern/pull/261/commits/30eb9b1a5882d6d06128605ed3b877424cb4f651

Fixes #99

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>