### PR TITLE
Validate /v1/register-application functionality without the API-key

### DIFF
--- a/server/api/openapi.yaml
+++ b/server/api/openapi.yaml
@@ -3428,6 +3428,8 @@ paths:
       tags:
       - IndividualServices
       summary: Adds to the list of known applications
+      description: |
+        'Registration service is not protected by operationKey. Receiving a de-registration request shall be assumed after passing wait time to approve from [/core-model-1-4:control-construct/profile-collection/profile=ro-2-0-0-integer-p-000/integer-profile-1-0:integer-profile-pac/integer-profile-configuration/integer-value]'
       operationId: registerApplication
       parameters:
       - name: user
@@ -3441,8 +3443,9 @@ paths:
           example: User Name
       - name: originator
         in: header
-        description: "'Identification for the system consuming the API, as defined\
-          \ in\n [/core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'\n"
+        description: |
+          'Identification for the system consuming the API, as defined in
+           [/core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
         required: true
         style: simple
         explode: false
@@ -3522,7 +3525,8 @@ paths:
                 type: integer
                 example: 850
             life-cycle-state:
-              description: "'Life cycle state of the consumed service find in [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-op-s-3001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'\n"
+              description: |
+                'Life cycle state of the consumed service find in [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-s-is-001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
               style: simple
               explode: false
               schema:
@@ -3536,42 +3540,6 @@ paths:
                 - UNKNOWN
                 - NOT_YET_DEFINED
         "400":
-          description: Response in case of errored service requests
-          headers:
-            x-correlator:
-              description: UUID for the service execution flow that allows to correlate
-                requests and responses. Its value must be identical at the response
-                compared with its corresponding request
-              style: simple
-              explode: false
-              schema:
-                pattern: "^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$"
-                type: string
-                example: 550e8400-e29b-11d4-a716-446655440000
-            exec-time:
-              description: "Value written by the service provider, reporting the total\
-                \ elapsed time for the execution, including all the additional processing\
-                \ needed to retrieve the data from the backend service. Expressed\
-                \ in milliseconds"
-              style: simple
-              explode: false
-              schema:
-                type: integer
-                example: 1100
-            backend-time:
-              description: "Value written by the service provider, reporting the elapsed\
-                \ time for data retrieval from the backend (service invocation, database\
-                \ access…). Expressed in milliseconds"
-              style: simple
-              explode: false
-              schema:
-                type: integer
-                example: 850
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorDescription'
-        "401":
           description: Response in case of errored service requests
           headers:
             x-correlator:
@@ -3753,55 +3721,172 @@ paths:
                 $ref: '#/components/schemas/errorDescription'
       callbacks:
         TypeApprovalCausesRequestForEmbedding:
-          https://{$request.body#application-address}:{$request.body#application-port}{$request.body#embedding-operation}:
+          url:
             post:
+              parameters:
+              - name: user
+                in: header
+                description: User identifier from the system starting the service
+                  call
+                required: true
+                style: simple
+                explode: false
+                schema:
+                  type: string
+                  example: User Name
+              - name: originator
+                in: header
+                description: |
+                  'Identification for the system consuming the API, as defined in
+                   [/core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
+                required: true
+                style: simple
+                explode: false
+                schema:
+                  minLength: 3
+                  type: string
+                  example: Resolver
+              - name: x-correlator
+                in: header
+                description: UUID for the service execution flow that allows to correlate
+                  requests and responses
+                required: true
+                style: simple
+                explode: false
+                schema:
+                  pattern: "^[0-9A-Fa-f]{8}(?:-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$"
+                  type: string
+                  description: Empty string accepted from external applications.
+                  example: 550e8400-e29b-11d4-a716-446655440000
+              - name: trace-indicator
+                in: header
+                description: Sequence of request numbers along the flow
+                required: true
+                style: simple
+                explode: false
+                schema:
+                  pattern: "^([0-9]+)(\\.([0-9]+))*$"
+                  type: string
+                  description: Empty string accepted from external applications.
+                  example: 1.3.1
+              - name: customer-journey
+                in: header
+                description: Holds information supporting customer’s journey to which
+                  the execution applies
+                required: true
+                style: simple
+                explode: false
+                schema:
+                  type: string
+                  example: Unknown value
               requestBody:
                 content:
                   application/json:
                     schema:
                       required:
                       - deregistration-operation
+                      - old-release-address
+                      - old-release-port
+                      - old-release-protocol
                       - registry-office-address
                       - registry-office-application
                       - registry-office-application-release-number
                       - registry-office-port
+                      - registry-office-protocol
                       - relay-operation-update-operation
                       - relay-server-replacement-operation
                       type: object
                       properties:
                         registry-office-application:
                           type: string
-                          description: "'Own application name from [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'\n"
+                          description: |
+                            'Own application name from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-http-s-bm-000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         registry-office-application-release-number:
                           type: string
-                          description: "'Own release number from [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'\n"
+                          description: |
+                            'Own release number from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-http-s-bm-000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         relay-server-replacement-operation:
                           type: string
-                          description: "'Operation for requesting for broadcasting\
-                            \ a new server address from [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-op-s-3010/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'\n"
+                          description: |
+                            'Operation for requesting for broadcasting a new server address from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-s-is-010/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                         relay-operation-update-operation:
                           type: string
-                          description: "'Operation for requesting for broadcasting\
-                            \ a backward compatible replacement of an operation from\
-                            \ [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-op-s-3011/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'\n"
+                          description: |
+                            'Operation for requesting for broadcasting a backward compatible replacement of an operation from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-s-is-011/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                         deregistration-operation:
                           type: string
-                          description: "'Operation for deregistering from the application\
-                            \ layer from [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-op-s-3002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'\n"
-                        registry-office-address:
+                          description: |
+                            'Operation for deregistering from the application layer from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-s-is-002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                        registry-office-protocol:
                           type: string
-                          description: "'Own IP address from [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]'\n"
+                          description: |
+                            'Protocol for addressing the RegistryOffice application from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-s-bm-000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-protocol]'
+                        registry-office-address:
+                          maxProperties: 1
+                          minProperties: 1
+                          type: object
+                          properties:
+                            ip-address:
+                              minProperties: 1
+                              type: object
+                              properties:
+                                ipv-4-address:
+                                  type: string
+                                  description: |
+                                    'Own IP address from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-s-bm-000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]'
+                              additionalProperties: false
+                            domain-name:
+                              type: string
+                              description: |
+                                'Own domain name from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-s-bm-000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/domain-name]'
+                          additionalProperties: false
                         registry-office-port:
                           type: integer
-                          description: "'Own TCP port from [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]'\n"
+                          description: |
+                            'Own TCP port from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-s-bm-000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]'
+                        old-release-protocol:
+                          type: string
+                          description: |
+                            'If application of the same name (but lower release number is already registered), Protocol for addressing the old release of the same application from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*-*-1-0-0-??0/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-protocol] otherwise protocol for addressing the newly approved application.'
+                        old-release-address:
+                          maxProperties: 1
+                          minProperties: 1
+                          type: object
+                          properties:
+                            ip-address:
+                              minProperties: 1
+                              type: object
+                              properties:
+                                ipv-4-address:
+                                  type: string
+                                  description: |
+                                    'If application of the same name (but lower release number is already registered), IPv4 address of the OldRelease from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*-*-1-0-0-??0/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address] otherwise IPv4 address of the newly approved application.'
+                              additionalProperties: false
+                            domain-name:
+                              type: string
+                              description: |
+                                'If application of the same name (but lower release number is already registered), domain name of the OldRelease from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*-*-1-0-0-??0/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name] otherwise domain-name of the newly approved application.'
+                          additionalProperties: false
+                        old-release-port:
+                          type: integer
+                          description: |
+                            'If application of the same name (but lower release number is already registered), TCP port of the OldRelease from [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*-*-1-0-0-??0/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port] otherwise TCP port of the newly approved application.'
                       example:
                         registry-office-application: RegistryOffice
-                        registry-office-application-release-number: 0.0.1
+                        registry-office-application-release-number: 2.0.0
                         relay-server-replacement-operation: /v1/relay-server-replacement
                         relay-operation-update-operation: /v1/relay-operation-update
                         deregistration-operation: /v1/deregister-application
-                        registry-office-address: 10.118.125.157
-                        registry-office-port: 1000
+                        registry-office-protocol: HTTP
+                        registry-office-address:
+                          ip-address:
+                            ipv-4-address: 1.1.3.8
+                        registry-office-port: 3008
+                        old-release-protocol: HTTP
+                        old-release-address:
+                          ip-address:
+                            ipv-4-address: 1.1.3.1
+                        old-release-port: 3001
                 required: true
               responses:
                 "204":
@@ -4065,14 +4150,6 @@ paths:
                     application/json:
                       schema:
                         $ref: '#/components/schemas/errorDescription'
-            parameters:
-            - $ref: '#/components/parameters/user'
-            - $ref: '#/components/parameters/originator'
-            - $ref: '#/components/parameters/x-correlator'
-            - $ref: '#/components/parameters/trace-indicator'
-            - $ref: '#/components/parameters/customer-journey'
-      security:
-      - apiKeyAuth: []
       x-swagger-router-controller: IndividualServices
   /v1/deregister-application:
     post:
@@ -21639,55 +21716,108 @@ components:
         - field-name: applicationName
           value: OwnApplicationName
           datatype: String
+    v1registerapplication_address_ipaddress:
+      minProperties: 1
+      type: object
+      properties:
+        ipv-4-address:
+          pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+          type: string
+          description: |
+            'IPv4 address of application that wants to register update or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+      additionalProperties: false
+    v1registerapplication_address:
+      maxProperties: 1
+      minProperties: 1
+      type: object
+      properties:
+        ip-address:
+          $ref: '#/components/schemas/v1registerapplication_address_ipaddress'
+        domain-name:
+          pattern: "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"
+          type: string
+          description: |
+            'Domain name of application that wants to register update or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+      additionalProperties: false
+    v1registerapplication_tcpserverlist:
+      required:
+      - address
+      - port
+      - protocol
+      type: object
+      properties:
+        protocol:
+          type: string
+          description: |
+            'Protocol to be used for addressing the application that wants to register find or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-protocol]'
+          enum:
+          - HTTP
+          - HTTPS
+        address:
+          $ref: '#/components/schemas/v1registerapplication_address'
+        port:
+          maximum: 65535
+          minimum: 0
+          type: integer
+          description: |
+            'TCP port of application that wants to register update or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
     v1_registerapplication_body:
       required:
-      - application-address
       - application-name
-      - application-port
       - application-release-number
       - client-update-operation
       - embedding-operation
+      - operation-client-update-operation
+      - tcp-server-list
       type: object
       properties:
         application-name:
           minLength: 3
           type: string
-          description: "'Name of application that wants to register find or create\
-            \ [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'\n"
+          description: |
+            'Name of application that wants to register find or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
         application-release-number:
-          pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\\
-            +[0-9A-Za-z-]+)?$"
+          pattern: "^([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{1,2})$"
           type: string
-          description: "'Release of application that wants to register find or create\
-            \ [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'\n"
+          description: |
+            'Release of application that wants to register find or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
         embedding-operation:
-          minLength: 3
+          minLength: 6
           type: string
-          description: "'Name of service for initiating embedding process update or\
-            \ create [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-op-c-*/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'\n"
+          description: |
+            'Name of service for initiating embedding process update or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-c-im-*-1-0-0-000/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
         client-update-operation:
-          minLength: 3
+          minLength: 6
           type: string
-          description: "'Name of service for broadcasting server changes update or\
-            \ create [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-op-c-*/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'\n"
-        application-address:
-          pattern: "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+          description: |
+            'Name of service for broadcasting server changes update or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-c-im-*-1-0-0-001/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+        operation-client-update-operation:
+          minLength: 6
           type: string
-          description: "'IP address of application that wants to register update or\
-            \ create [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'\n"
-        application-port:
-          maximum: 65535
-          minimum: 0
-          type: integer
-          description: "'TCP port of application that wants to register update or\
-            \ create [/core-model-1-4:control-construct/logical-termination-point=ro-0-0-1-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'\n"
+          description: |
+            'Name of service for broadcasting replacements of operations by backward compatible substitutes update or create [/core-model-1-4:control-construct/logical-termination-point=ro-2-0-0-op-c-im-*-1-0-0-002/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+        tcp-server-list:
+          minItems: 1
+          type: array
+          items:
+            $ref: '#/components/schemas/v1registerapplication_tcpserverlist'
       example:
         application-name: TypeApprovalRegister
-        application-release-number: 0.0.1
+        application-release-number: 1.0.0
         embedding-operation: /v1/embed-yourself
         client-update-operation: /v1/update-client
-        application-address: 10.118.125.157
-        application-port: 1001
+        operation-client-update-operation: /v1/update-operation-client
+        tcp-server-list:
+        - protocol: HTTP
+          address:
+            ip-address:
+              ipv-4-address: 1.1.3.9
+          port: 3009
+        - protocol: HTTPS
+          address:
+            ip-address:
+              ipv-4-address: 1.2.3.9
+          port: 3209
     v1_deregisterapplication_body:
       required:
       - application-name


### PR DESCRIPTION
Fixes #210

Method signature of the service registerApplication in controllers/IndividualServices.js and service/IndividualServicesService.js  doesnt require a change for the new version. 
updated api/openapi.yaml as per the latest version 2.0.0 ,to the the api/openapi.yaml file from the generated stub to the source code.
Validated the scenario.