### PR TITLE
The request body formulation for callback "PromptForBequeathingDataCausesTransferOfListOfAlreadyRegisteredApplications" during bequeath-your-data-and-die is wrong

### DIFF
--- a/server/service/individualServices/PrepareForwardingAutomation.js
+++ b/server/service/individualServices/PrepareForwardingAutomation.js
@@ -129,10 +129,7 @@ exports.updateApprovalStatusApproved = function (logicalTerminationPointconfigur
             let deregistrationOperationUuid = controlConstructUuid + "-op-s-is-002";
             embedYourselfRequestBody.deregistrationOperation = await operationServerInterface.getOperationNameAsync(deregistrationOperationUuid);
             
-            let registryOfficeAddress = await tcpServerInterface.getLocalAddress();
-            embedYourselfRequestBody.registryOfficeAddress = {
-                "ip-address" : registryOfficeAddress
-            }
+            embedYourselfRequestBody.registryOfficeAddress =  await tcpServerInterface.getLocalAddressForForwarding();
             embedYourselfRequestBody.registryOfficePort = await tcpServerInterface.getLocalPort();
             embedYourselfRequestBody.registryOfficeProtocol = await tcpServerInterface.getLocalProtocol()
 

--- a/server/service/individualServices/SoftwareUpgrade.js
+++ b/server/service/individualServices/SoftwareUpgrade.js
@@ -232,7 +232,7 @@ async function promptForBequeathingDataCausesTransferOfListOfAlreadyRegisteredAp
                             httpClientUuid
                         );
                         if (clientUpdateOperationName == undefined) {
-                            embeddingOperationName = "/v1/update-client"
+                            clientUpdateOperationName = "/v1/update-client"
                         }
 
                         operationClientUpdateOperation = await resolveOperationNameForAHttpClientFromForwardingName(
@@ -240,7 +240,7 @@ async function promptForBequeathingDataCausesTransferOfListOfAlreadyRegisteredAp
                             httpClientUuid
                         );
                         if (operationClientUpdateOperation == undefined) {
-                            embeddingOperationName = "/v1/update-operation-client"
+                            operationClientUpdateOperation = "/v1/update-operation-client"
                         }
 
                         /******************************************************************************************


### PR DESCRIPTION
Fixes #412
Modified embed-yourself forwarding to fetch localAddress from new method in AP
Merge after AP #712